### PR TITLE
MySQLDBStore.readTable

### DIFF
--- a/external/mlsql-mysql-store/src/main/java/tech/mlsql/runtime/metastore/MySQLDBStore.scala
+++ b/external/mlsql-mysql-store/src/main/java/tech/mlsql/runtime/metastore/MySQLDBStore.scala
@@ -53,7 +53,7 @@ class MySQLDBStore extends DBStore {
     val convertRowToMap = (row: Row) => {
       row.schema.fieldNames.filter(field => !row.isNullAt(row.fieldIndex(field))).map(field => field -> row.getAs[String](field)).toMap
     }
-    val udf = F.udf(convertRowToMap, MapType(StringType, StringType))
+    val udf = F.udf(convertRowToMap)
     data.schema.filter(f => f.dataType match {
       case StructType(_) => true
       case _ => false

--- a/streamingpro-mlsql/src/main/java/streaming/dsl/mmlib/algs/SQLTreeBuildExt.scala
+++ b/streamingpro-mlsql/src/main/java/streaming/dsl/mmlib/algs/SQLTreeBuildExt.scala
@@ -114,7 +114,7 @@ class SQLTreeBuildExt(override val uid: String) extends SQLAlg with Functions wi
       }
       computeLevel(a, level)
     }
-    val computeLevelUDF = F.udf(computeLevel1, IntegerType)
+    val computeLevelUDF = F.udf(computeLevel1)
     newdf = newdf.withColumn("level", computeLevelUDF(F.col("children"), F.lit(0)))
 
     $(treeType) match {


### PR DESCRIPTION
# What changes were proposed in this pull request?
MySQLDBStore.readTable(MySQLDBStore.scala:56) will throws exception :

```
You're using untyped Scala UDF, which does not have the input type information. Spark may blindly pass null to the Scala closure with primitive-type argument, and the closure will see the default value of the Java type for the null argument, e.g. `udf((x: Int) => x, IntegerType)`, the result is 0 for null input. To get rid of this error, you could:
1. use typed Scala UDF APIs(without return type parameter), e.g. `udf((x: Int) => x)`
2. use Java UDF APIs, e.g. `udf(new UDF1[String, Integer] { override def call(s: String): Integer = s.length() }, IntegerType)`, if input types are all non primitive
3. set spark.sql.legacy.allowUntypedScalaUDF to true and use this API with caution
org.apache.spark.sql.AnalysisException: You're using untyped Scala UDF, which does not have the input type information. Spark may blindly pass null to the Scala closure with primitive-type argument, and the closure will see the default value of the Java type for the null argument, e.g. `udf((x: Int) => x, IntegerType)`, the result is 0 for null input. To get rid of this error, you could:
1. use typed Scala UDF APIs(without return type parameter), e.g. `udf((x: Int) => x)`
2. use Java UDF APIs, e.g. `udf(new UDF1[String, Integer] { override def call(s: String): Integer = s.length() }, IntegerType)`, if input types are all non primitive
3. set spark.sql.legacy.allowUntypedScalaUDF to true and use this API with caution
org.apache.spark.sql.functions$.udf(functions.scala:5021)
tech.mlsql.runtime.metastore.MySQLDBStore.readTable(MySQLDBStore.scala:56)
tech.mlsql.ets.PluginCommand.train(PluginCommand.scala:177)
tech.mlsql.dsl.adaptor.TrainAdaptor.parse(TrainAdaptor.scala:116)
streaming.dsl.ScriptSQLExecListener.execute$1(ScriptSQLExec.scala:368)
streaming.dsl.ScriptSQLExecListener.exitSql(ScriptSQLExec.scal
```
# How was this patch tested?
- [ ] Testing done

# Are there and DOC need to update?
- [ ] Doc is finished

# Spark Core Compatibility
